### PR TITLE
feat: add Healthy Hawker Budget POC (GOOD_SG-026)

### DIFF
--- a/app/pocs/healthy-hawker-budget-sg/data.ts
+++ b/app/pocs/healthy-hawker-budget-sg/data.ts
@@ -1,0 +1,183 @@
+export const STORAGE_KEY = "cfg-healthy-hawker-budget-sg-v1";
+
+export const mealSlots = [
+  {
+    id: "breakfast",
+    label: "Breakfast",
+    timeLabel: "Before work",
+    prompt: "Pick a lighter start that keeps you full through the morning.",
+    accent: "#cc5a2d",
+  },
+  {
+    id: "lunch",
+    label: "Lunch",
+    timeLabel: "Midday",
+    prompt: "Choose the main plate that does the heavy lifting for the day.",
+    accent: "#2f7d59",
+  },
+  {
+    id: "tea",
+    label: "Tea",
+    timeLabel: "Late afternoon",
+    prompt: "Keep the snack steady so dinner does not turn into a splurge.",
+    accent: "#d98b2b",
+  },
+  {
+    id: "dinner",
+    label: "Dinner",
+    timeLabel: "Evening",
+    prompt: "Finish with a familiar hawker meal that still leaves room in the budget.",
+    accent: "#8f3d2e",
+  },
+] as const;
+
+export type MealSlotId = (typeof mealSlots)[number]["id"];
+
+export type Dish = {
+  id: string;
+  meal: MealSlotId;
+  name: string;
+  stall: string;
+  price: number;
+  calories: number;
+  badge: string;
+  summary: string;
+  healthNote: string;
+  swapTip: string;
+  accent: string;
+  paper: string;
+};
+
+export type PlannerState = {
+  activeMeal: MealSlotId;
+  selectedByMeal: Partial<Record<MealSlotId, string>>;
+};
+
+export const dishes: Dish[] = [
+  {
+    id: "soy-milk-eggs",
+    meal: "breakfast",
+    name: "Soy milk with two eggs",
+    stall: "Morning drink stall",
+    price: 2.4,
+    calories: 280,
+    badge: "Protein start",
+    summary: "Warm soy milk and eggs for a filling start without fried sides.",
+    healthNote: "Protein lands early, so you are less likely to hunt for pastries by 10am.",
+    swapTip: "If you usually add kaya toast, keep it to one slice and keep the eggs.",
+    accent: "#cc5a2d",
+    paper: "linear-gradient(145deg, #fff1e7, #f7d6c2)",
+  },
+  {
+    id: "yong-tau-foo-breakfast",
+    meal: "breakfast",
+    name: "Yong tau foo soup set",
+    stall: "Soup corner",
+    price: 4.2,
+    calories: 360,
+    badge: "Soup option",
+    summary: "Six pieces in broth with rice for a steadier breakfast on a long day.",
+    healthNote: "Soup and tofu keep the morning lighter than fried noodles.",
+    swapTip: "Go easy on sweet sauce and choose more tofu than fish cake.",
+    accent: "#8f3d2e",
+    paper: "linear-gradient(145deg, #f7ebe1, #ead0be)",
+  },
+  {
+    id: "sliced-fish-soup",
+    meal: "lunch",
+    name: "Sliced fish soup with rice",
+    stall: "Fish soup stall",
+    price: 5.5,
+    calories: 430,
+    badge: "Lean lunch",
+    summary: "A dependable lunch when you want something warm without the afternoon slump.",
+    healthNote: "You still get a proper meal, but with less oil than a fried rice plate.",
+    swapTip: "Ask for extra greens and keep the soup clear.",
+    accent: "#2f7d59",
+    paper: "linear-gradient(145deg, #eef7ef, #d1e7d5)",
+  },
+  {
+    id: "thunder-tea-rice",
+    meal: "lunch",
+    name: "Thunder tea rice",
+    stall: "Lei cha stall",
+    price: 5.2,
+    calories: 520,
+    badge: "Veg-heavy",
+    summary: "Rice, peanuts, tofu, and chopped greens when you want a fuller bowl at a fair price.",
+    healthNote: "It packs fibre and texture, which helps lunch stay satisfying.",
+    swapTip: "Keep the anchovies if you want more savoury bite without adding another dish.",
+    accent: "#4f8b45",
+    paper: "linear-gradient(145deg, #f1f7e4, #dce8c8)",
+  },
+  {
+    id: "fruit-cup-nuts",
+    meal: "tea",
+    name: "Fruit cup with nuts",
+    stall: "Cut fruit stand",
+    price: 2.8,
+    calories: 190,
+    badge: "Sweet fix",
+    summary: "A quick sweet bite that keeps tea light enough for dinner later.",
+    healthNote: "You still get crunch and sweetness without sinking the whole day.",
+    swapTip: "Choose guava or papaya if you want more fibre for the same spend.",
+    accent: "#d98b2b",
+    paper: "linear-gradient(145deg, #fff6df, #f2dfb4)",
+  },
+  {
+    id: "tau-huay",
+    meal: "tea",
+    name: "Tau huay",
+    stall: "Bean curd cart",
+    price: 1.6,
+    calories: 160,
+    badge: "Budget snack",
+    summary: "Soft bean curd for an afternoon lift when you need something cheap and easy.",
+    healthNote: "Keeps the snack affordable enough to leave room for dinner.",
+    swapTip: "Skip extra syrup if breakfast already ran sweet.",
+    accent: "#b9782c",
+    paper: "linear-gradient(145deg, #fff6e6, #eed4ae)",
+  },
+  {
+    id: "chicken-rice-veg",
+    meal: "dinner",
+    name: "Chicken rice with extra cucumber",
+    stall: "Roast meat stall",
+    price: 4.5,
+    calories: 510,
+    badge: "Classic dinner",
+    summary: "A familiar dinner that still works when you keep the plate clean and simple.",
+    healthNote: "Roasted or poached chicken keeps dinner grounded without feeling punishing.",
+    swapTip: "Ask for less rice if lunch was heavier than planned.",
+    accent: "#8f3d2e",
+    paper: "linear-gradient(145deg, #f8ece4, #e6cdbf)",
+  },
+  {
+    id: "yong-tau-foo-dinner",
+    meal: "dinner",
+    name: "Yong tau foo dry set",
+    stall: "Evening soup stall",
+    price: 4.8,
+    calories: 440,
+    badge: "Flexible dinner",
+    summary: "Pick more vegetables and tofu for a dinner that still feels like a proper hawker meal.",
+    healthNote: "Easy to adjust up or down depending on how the rest of the day went.",
+    swapTip: "Keep one noodle portion instead of adding fried items on the side.",
+    accent: "#6f4a3b",
+    paper: "linear-gradient(145deg, #f6ede4, #e7d6ca)",
+  },
+];
+
+export const defaultState: PlannerState = {
+  activeMeal: "breakfast",
+  selectedByMeal: {},
+};
+
+export function getDish(dishId?: string) {
+  if (!dishId) return null;
+  return dishes.find((dish) => dish.id === dishId) ?? null;
+}
+
+export function getMealSlot(mealId: MealSlotId) {
+  return mealSlots.find((slot) => slot.id === mealId) ?? mealSlots[0];
+}

--- a/app/pocs/healthy-hawker-budget-sg/layout.tsx
+++ b/app/pocs/healthy-hawker-budget-sg/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+
+import { getPocBySlug } from "@/lib/pocs";
+
+const poc = getPocBySlug("healthy-hawker-budget-sg");
+
+export const metadata: Metadata = {
+  title: poc?.title ?? "Healthy Hawker Budget",
+  description: poc?.summary ?? "Build a healthier hawker day without overspending.",
+  keywords: poc?.tags ?? ["Wellness", "Food", "Budget", "Singapore"],
+  openGraph: {
+    title: poc?.title ?? "Healthy Hawker Budget",
+    description: poc?.summary ?? "Build a healthier hawker day without overspending.",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: poc?.title ?? "Healthy Hawker Budget",
+    description: poc?.summary ?? "Build a healthier hawker day without overspending.",
+  },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/pocs/healthy-hawker-budget-sg/page.module.css
+++ b/app/pocs/healthy-hawker-budget-sg/page.module.css
@@ -1,0 +1,380 @@
+.page {
+  min-height: 100dvh;
+  background:
+    radial-gradient(circle at 16% 18%, rgba(204, 90, 45, 0.16), transparent 24%),
+    radial-gradient(circle at 82% 12%, rgba(47, 125, 89, 0.16), transparent 22%),
+    linear-gradient(180deg, #fbf2e5 0%, #f3eadf 46%, #efe4d6 100%);
+  color: #4a2f21;
+  font-family: var(--font-hawker-budget-body), sans-serif;
+}
+
+.shell {
+  width: min(1240px, calc(100% - 28px));
+  margin: 0 auto;
+  padding: 24px 0 56px;
+}
+
+.backLink {
+  display: inline-flex;
+  margin-bottom: 18px;
+  color: #7b3f2f;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.hero,
+.stage {
+  display: grid;
+  gap: 24px;
+}
+
+.hero {
+  grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
+  align-items: start;
+  margin-bottom: 26px;
+}
+
+.heroCopy h1,
+.summaryBoard h2,
+.boardTopline h2,
+.dishCard strong,
+.trayDish strong,
+.footerNote strong,
+.totalsRow strong,
+.mealTab strong {
+  font-family: var(--font-hawker-budget-display), serif;
+}
+
+.eyebrow,
+.summaryLabel,
+.boardLabel,
+.slotHeader p,
+.mealTab span,
+.totalsRow span,
+.summaryNote,
+.boardHint,
+.dishBadge {
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.eyebrow,
+.summaryLabel,
+.boardLabel {
+  margin: 0 0 10px;
+  color: #8d5338;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.heroCopy h1 {
+  max-width: 10ch;
+  margin: 0;
+  font-size: clamp(3.2rem, 6vw, 5.4rem);
+  line-height: 0.9;
+  letter-spacing: -0.05em;
+}
+
+.lede {
+  max-width: 44ch;
+  margin: 16px 0 0;
+  color: #6f5242;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.mealTabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.mealTab,
+.dishCard,
+.summaryBoard,
+.menuBoard,
+.trayBoard,
+.traySlot,
+.footerNote {
+  border: 1px solid rgba(87, 58, 43, 0.12);
+  box-shadow: 0 24px 48px rgba(82, 53, 40, 0.08);
+}
+
+.mealTab {
+  padding: 14px 14px 12px;
+  border-radius: 24px;
+  background: rgba(255, 251, 245, 0.8);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.mealTab strong {
+  display: block;
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.mealTab span,
+.summaryNote,
+.boardHint,
+.slotHeader span,
+.dishCard em,
+.dishMeta span,
+.trayDish em,
+.trayMeta span,
+.footerNote span,
+.slotEmpty {
+  color: #7c6355;
+  font-size: 0.78rem;
+  font-style: normal;
+}
+
+.mealTabActive {
+  border-color: color-mix(in srgb, var(--slot-accent) 46%, #764734);
+  background: linear-gradient(180deg, rgba(255,255,255,0.9), color-mix(in srgb, var(--slot-accent) 12%, white));
+}
+
+.summaryBoard,
+.menuBoard,
+.trayBoard {
+  border-radius: 34px;
+  background: rgba(255, 252, 247, 0.78);
+}
+
+.summaryBoard {
+  padding: 22px;
+}
+
+.summaryHeader,
+.boardTopline,
+.slotHeader,
+.totalsRow {
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.summaryHeader,
+.boardTopline {
+  align-items: flex-start;
+}
+
+.summaryBoard h2,
+.boardTopline h2 {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 3rem);
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+}
+
+.railWrap {
+  height: 176px;
+  margin: 18px 0;
+  padding: 12px;
+  border-radius: 24px;
+  background: linear-gradient(180deg, rgba(244, 231, 216, 0.66), rgba(255,255,255,0.76));
+}
+
+.totalsRow {
+  flex-wrap: wrap;
+}
+
+.totalsRow div {
+  min-width: 120px;
+}
+
+.totalsRow strong {
+  display: block;
+  margin-top: 4px;
+  font-size: 1.7rem;
+  line-height: 1;
+}
+
+.stage {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0.94fr);
+}
+
+.menuBoard,
+.trayBoard {
+  padding: 22px;
+}
+
+.menuGrid,
+.trayGrid,
+.footerStrip {
+  display: grid;
+  gap: 14px;
+}
+
+.menuGrid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 18px;
+}
+
+.dishCard {
+  padding: 18px;
+  border-radius: 28px;
+  background:
+    linear-gradient(180deg, rgba(255,255,255,0.86), rgba(255,255,255,0.7)),
+    var(--dish-paper);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.dishBadge {
+  display: inline-flex;
+  min-height: 28px;
+  padding: 0 10px;
+  align-items: center;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.68);
+  color: color-mix(in srgb, var(--dish-accent) 68%, #5a3426);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.dishCard strong,
+.trayDish strong {
+  display: block;
+  margin-top: 12px;
+  font-size: 1.8rem;
+  line-height: 0.92;
+}
+
+.dishCard p,
+.trayDish p {
+  margin: 12px 0 0;
+  color: #684f40;
+  line-height: 1.55;
+}
+
+.dishMeta,
+.dishNotes,
+.trayMeta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+.dishNotes span,
+.trayMeta span,
+.dishMeta span,
+.clearButton,
+.footerNote span {
+  display: inline-flex;
+  min-height: 30px;
+  padding: 0 11px;
+  align-items: center;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.74);
+}
+
+.trayGrid {
+  margin-top: 18px;
+}
+
+.traySlot {
+  padding: 16px;
+  border-radius: 28px;
+  background: rgba(255,255,255,0.68);
+  cursor: pointer;
+}
+
+.traySlotActive {
+  border-color: color-mix(in srgb, var(--slot-accent) 48%, #744734);
+  box-shadow: 0 18px 36px rgba(82, 53, 40, 0.12);
+}
+
+.slotHeader p,
+.slotHeader span {
+  margin: 0;
+}
+
+.clearButton {
+  border: none;
+  color: #704636;
+  cursor: pointer;
+}
+
+.trayDish {
+  margin-top: 14px;
+  padding: 16px;
+  border-radius: 24px;
+  background:
+    linear-gradient(180deg, rgba(255,255,255,0.88), rgba(255,255,255,0.74)),
+    var(--dish-paper);
+}
+
+.slotEmpty {
+  margin-top: 14px;
+  padding: 16px;
+  border-radius: 24px;
+  background: linear-gradient(180deg, rgba(245, 235, 222, 0.7), rgba(255,255,255,0.62));
+  line-height: 1.55;
+}
+
+.footerStrip {
+  margin-top: 18px;
+}
+
+.footerNote {
+  padding: 16px 18px;
+  border-radius: 22px;
+  background: color-mix(in srgb, var(--slot-accent) 10%, white);
+}
+
+.footerNote strong {
+  display: block;
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.footerNote span {
+  margin-top: 10px;
+  padding: 0;
+  min-height: 0;
+  background: transparent;
+  line-height: 1.5;
+}
+
+@media (max-width: 1120px) {
+  .hero,
+  .stage {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .shell {
+    width: min(100% - 20px, 1240px);
+    padding-bottom: 40px;
+  }
+
+  .heroCopy h1 {
+    max-width: none;
+    font-size: clamp(2.4rem, 12vw, 4.5rem);
+  }
+
+  .mealTabs,
+  .menuGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .summaryHeader,
+  .boardTopline,
+  .slotHeader,
+  .totalsRow {
+    flex-direction: column;
+  }
+
+  .summaryBoard,
+  .menuBoard,
+  .trayBoard {
+    padding: 18px;
+    border-radius: 26px;
+  }
+}

--- a/app/pocs/healthy-hawker-budget-sg/page.tsx
+++ b/app/pocs/healthy-hawker-budget-sg/page.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import Link from "next/link";
+import { Cormorant_Garamond, Source_Sans_3 } from "next/font/google";
+import { AnimatePresence, motion } from "framer-motion";
+import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  defaultState,
+  dishes,
+  getDish,
+  getMealSlot,
+  mealSlots,
+  STORAGE_KEY,
+  type MealSlotId,
+  type PlannerState,
+} from "./data";
+import styles from "./page.module.css";
+
+const cormorant = Cormorant_Garamond({
+  subsets: ["latin"],
+  variable: "--font-hawker-budget-display",
+  weight: ["500", "600", "700"],
+});
+
+const sourceSans = Source_Sans_3({
+  subsets: ["latin"],
+  variable: "--font-hawker-budget-body",
+  weight: ["400", "500", "600", "700"],
+});
+
+function loadState() {
+  if (typeof window === "undefined") return defaultState;
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultState;
+
+    const parsed = JSON.parse(raw) as PlannerState;
+    return {
+      activeMeal: mealSlots.some((slot) => slot.id === parsed.activeMeal)
+        ? parsed.activeMeal
+        : defaultState.activeMeal,
+      selectedByMeal: parsed.selectedByMeal ?? {},
+    };
+  } catch {
+    return defaultState;
+  }
+}
+
+function formatCurrency(value: number) {
+  return `$${value.toFixed(2)}`;
+}
+
+function formatCalories(value: number) {
+  return `${value} kcal`;
+}
+
+function nextEmptyMeal(current: Partial<Record<MealSlotId, string>>) {
+  return mealSlots.find((slot) => current[slot.id] === undefined)?.id ?? null;
+}
+
+export default function HealthyHawkerBudgetPage() {
+  const [hydrated, setHydrated] = useState(false);
+  const [plannerState, setPlannerState] = useState<PlannerState>(defaultState);
+
+  useEffect(() => {
+    setPlannerState(loadState());
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(plannerState));
+  }, [hydrated, plannerState]);
+
+  const selectedMeals = useMemo(
+    () =>
+      mealSlots.map((slot) => ({
+        slot,
+        dish: getDish(plannerState.selectedByMeal[slot.id]),
+      })),
+    [plannerState.selectedByMeal],
+  );
+
+  const activeSlot = getMealSlot(plannerState.activeMeal);
+  const activeDishes = dishes.filter((dish) => dish.meal === plannerState.activeMeal);
+  const totalSpend = selectedMeals.reduce((sum, item) => sum + (item.dish?.price ?? 0), 0);
+  const totalCalories = selectedMeals.reduce((sum, item) => sum + (item.dish?.calories ?? 0), 0);
+  const selectedCount = selectedMeals.filter((item) => item.dish).length;
+
+  const railData = [
+    mealSlots.reduce((row, slot) => {
+      row.metric = "Spend";
+      row[slot.id] = getDish(plannerState.selectedByMeal[slot.id])?.price ?? 0;
+      return row;
+    }, {} as Record<string, number | string>),
+    mealSlots.reduce((row, slot) => {
+      row.metric = "Calories";
+      row[slot.id] = getDish(plannerState.selectedByMeal[slot.id])?.calories ?? 0;
+      return row;
+    }, {} as Record<string, number | string>),
+  ];
+
+  function assignDish(dishId: string) {
+    setPlannerState((current) => {
+      const selectedByMeal = {
+        ...current.selectedByMeal,
+        [current.activeMeal]: dishId,
+      };
+      const nextMeal = nextEmptyMeal(selectedByMeal);
+
+      return {
+        activeMeal: nextMeal ?? current.activeMeal,
+        selectedByMeal,
+      };
+    });
+  }
+
+  function clearMeal(mealId: MealSlotId) {
+    setPlannerState((current) => {
+      const selectedByMeal = { ...current.selectedByMeal };
+      delete selectedByMeal[mealId];
+
+      return {
+        activeMeal: mealId,
+        selectedByMeal,
+      };
+    });
+  }
+
+  return (
+    <main className={`${styles.page} ${cormorant.variable} ${sourceSans.variable}`}>
+      <div className={styles.shell}>
+        <Link href="/" className={styles.backLink}>
+          ← Back to gallery
+        </Link>
+
+        <section className={styles.hero}>
+          <div className={styles.heroCopy}>
+            <p className={styles.eyebrow}>Healthy Hawker Budget</p>
+            <h1>Build a healthier hawker day without overspending.</h1>
+            <p className={styles.lede}>
+              Choose the meal you are filling, then tap one familiar dish to place it on today&apos;s tray.
+            </p>
+
+            <div className={styles.mealTabs} aria-label="Choose the meal you are filling">
+              {mealSlots.map((slot) => (
+                <button
+                  key={slot.id}
+                  type="button"
+                  className={`${styles.mealTab} ${slot.id === plannerState.activeMeal ? styles.mealTabActive : ""}`}
+                  onClick={() => setPlannerState((current) => ({ ...current, activeMeal: slot.id }))}
+                  style={{ ["--slot-accent" as string]: slot.accent }}
+                >
+                  <strong>{slot.label}</strong>
+                  <span>{slot.timeLabel}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <section className={styles.summaryBoard}>
+            <div className={styles.summaryHeader}>
+              <div>
+                <p className={styles.summaryLabel}>Today&apos;s running rail</p>
+                <h2>{selectedCount === 0 ? "Start with one dish" : `${selectedCount} meal${selectedCount === 1 ? "" : "s"} now on the tray`}</h2>
+              </div>
+              <span className={styles.summaryNote}>
+                {totalSpend <= 16 ? "Comfortable for a weekday hawker spend." : "Lunch and dinner now carry most of the spend."}
+              </span>
+            </div>
+
+            <div className={styles.railWrap}>
+              <ResponsiveContainer width="100%" height={176}>
+                <BarChart data={railData} layout="vertical" margin={{ left: 0, right: 8, top: 12, bottom: 0 }}>
+                  <XAxis type="number" hide />
+                  <YAxis dataKey="metric" type="category" axisLine={false} tickLine={false} width={76} />
+                  <Tooltip
+                    cursor={false}
+                    contentStyle={{ borderRadius: 18, border: "1px solid rgba(75, 50, 33, 0.12)", boxShadow: "0 14px 28px rgba(75, 50, 33, 0.12)" }}
+                    formatter={(value, key, item) => {
+                      const numericValue = Number(value);
+                      const label = mealSlots.find((slot) => slot.id === key)?.label ?? String(key);
+                      const measure = item.payload.metric === "Spend" ? formatCurrency(numericValue) : formatCalories(numericValue);
+                      return [measure, label];
+                    }}
+                  />
+                  {mealSlots.map((slot) => (
+                    <Bar key={slot.id} dataKey={slot.id} stackId="totals" fill={slot.accent} radius={slot.id === "dinner" ? [16, 16, 16, 16] : [0, 0, 0, 0]} animationDuration={420} />
+                  ))}
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+
+            <div className={styles.totalsRow}>
+              <div>
+                <span>Spend</span>
+                <strong>{formatCurrency(totalSpend)}</strong>
+              </div>
+              <div>
+                <span>Calories</span>
+                <strong>{formatCalories(totalCalories)}</strong>
+              </div>
+              <div>
+                <span>Best next move</span>
+                <strong>{activeSlot.label}</strong>
+              </div>
+            </div>
+          </section>
+        </section>
+
+        <section className={styles.stage}>
+          <section className={styles.menuBoard}>
+            <div className={styles.boardTopline}>
+              <div>
+                <p className={styles.boardLabel}>Choose a dish for {activeSlot.label.toLowerCase()}</p>
+                <h2>{activeSlot.prompt}</h2>
+              </div>
+              <span className={styles.boardHint}>Tap once to place it on the tray.</span>
+            </div>
+
+            <div className={styles.menuGrid}>
+              {activeDishes.map((dish) => (
+                <motion.button
+                  key={dish.id}
+                  type="button"
+                  className={styles.dishCard}
+                  onClick={() => assignDish(dish.id)}
+                  initial={{ opacity: 0, y: 18, rotate: -1 }}
+                  animate={{ opacity: 1, y: 0, rotate: 0 }}
+                  transition={{ duration: 0.25, ease: "easeOut" }}
+                  style={{ ["--dish-accent" as string]: dish.accent, ["--dish-paper" as string]: dish.paper }}
+                >
+                  <span className={styles.dishBadge}>{dish.badge}</span>
+                  <strong>{dish.name}</strong>
+                  <em>{dish.stall}</em>
+                  <p>{dish.summary}</p>
+                  <div className={styles.dishMeta}>
+                    <span>{formatCurrency(dish.price)}</span>
+                    <span>{formatCalories(dish.calories)}</span>
+                  </div>
+                  <div className={styles.dishNotes}>
+                    <span>{dish.healthNote}</span>
+                    <span>{dish.swapTip}</span>
+                  </div>
+                </motion.button>
+              ))}
+            </div>
+          </section>
+
+          <section className={styles.trayBoard}>
+            <div className={styles.boardTopline}>
+              <div>
+                <p className={styles.boardLabel}>Today&apos;s tray</p>
+                <h2>Four meal moments, one running spend.</h2>
+              </div>
+              <span className={styles.boardHint}>Filled slots can be swapped anytime.</span>
+            </div>
+
+            <div className={styles.trayGrid}>
+              <AnimatePresence initial={false}>
+                {selectedMeals.map(({ slot, dish }) => (
+                  <motion.section
+                    key={slot.id}
+                    className={`${styles.traySlot} ${slot.id === plannerState.activeMeal ? styles.traySlotActive : ""}`}
+                    onClick={() => setPlannerState((current) => ({ ...current, activeMeal: slot.id }))}
+                    style={{ ["--slot-accent" as string]: slot.accent }}
+                    layout
+                  >
+                    <div className={styles.slotHeader}>
+                      <div>
+                        <p>{slot.label}</p>
+                        <span>{slot.timeLabel}</span>
+                      </div>
+                      {dish ? (
+                        <button
+                          type="button"
+                          className={styles.clearButton}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            clearMeal(slot.id);
+                          }}
+                        >
+                          Clear
+                        </button>
+                      ) : null}
+                    </div>
+
+                    {dish ? (
+                      <motion.div
+                        key={dish.id}
+                        className={styles.trayDish}
+                        initial={{ opacity: 0, y: 24, scale: 0.96 }}
+                        animate={{ opacity: 1, y: 0, scale: 1 }}
+                        exit={{ opacity: 0, y: -18, scale: 0.96 }}
+                        transition={{ duration: 0.28, ease: "easeOut" }}
+                        style={{ ["--dish-accent" as string]: dish.accent, ["--dish-paper" as string]: dish.paper }}
+                      >
+                        <strong>{dish.name}</strong>
+                        <em>{dish.stall}</em>
+                        <div className={styles.trayMeta}>
+                          <span>{formatCurrency(dish.price)}</span>
+                          <span>{formatCalories(dish.calories)}</span>
+                        </div>
+                        <p>{dish.healthNote}</p>
+                      </motion.div>
+                    ) : (
+                      <div className={styles.slotEmpty}>
+                        Add one dish here so your {slot.label.toLowerCase()} has a clear plan.
+                      </div>
+                    )}
+                  </motion.section>
+                ))}
+              </AnimatePresence>
+            </div>
+
+            <div className={styles.footerStrip}>
+              {selectedMeals.some((item) => item.dish) ? (
+                selectedMeals.filter((item) => item.dish).map(({ slot, dish }) => (
+                  <div key={slot.id} className={styles.footerNote} style={{ ["--slot-accent" as string]: slot.accent }}>
+                    <strong>{slot.label}</strong>
+                    <span>{dish?.swapTip}</span>
+                  </div>
+                ))
+              ) : (
+                <div className={styles.footerNote} style={{ ["--slot-accent" as string]: activeSlot.accent }}>
+                  <strong>Start here</strong>
+                  <span>Pick one dish for {activeSlot.label.toLowerCase()} and the running rail will begin to split by meal.</span>
+                </div>
+              )}
+            </div>
+          </section>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/ideas/GOOD_SG.json
+++ b/ideas/GOOD_SG.json
@@ -11216,7 +11216,8 @@
         "avoid": "generic nutrition table; form with dropdowns; anything without the meal-building interaction",
         "experience_goal": "user plans an affordable and reasonably healthy day of hawker meals without a spreadsheet"
       },
-      "implemented": false
+      "implemented": true,
+      "built": true
     },
     {
       "id": "GOOD_SG-076",

--- a/lib/pocs.ts
+++ b/lib/pocs.ts
@@ -11,6 +11,18 @@ export type PocCard = {
 
 export const pocCards: PocCard[] = [
   {
+    slug: "healthy-hawker-budget-sg",
+    title: "Healthy Hawker Budget",
+    category: "Wellness",
+    createdAt: "2026-03-29T18:40:00+08:00",
+    summary:
+      "Build a day of hawker meals that feels familiar, lighter, and still manageable on a weekday budget.",
+    impact:
+      "An editorial hawker spread that turns everyday dish choices into a visible daily spend plan.",
+    theme: "editorial",
+    tags: ["Wellness", "Food", "Budget", "Hawker"],
+  },
+  {
     slug: "low-cost-exercise-sg",
     title: "Low-Cost Exercise",
     category: "Wellness",


### PR DESCRIPTION
## POC: Healthy Hawker Budget

Implements idea `GOOD_SG-026` from `ideas/GOOD_SG.json`.

**Target user:** working adults and families
**Category:** wellness

### What was built
- An editorial hawker meal spread with meal-by-meal dish picking for breakfast, lunch, tea, and dinner
- A live stacked spend-and-calorie rail that splits by meal category as the tray fills
- Motion-led tray updates, local save state, and swap tips that keep the first screen focused on the next dish choice
- Distinctive feature: added dishes animate into the tray while the running rail reshapes around the new meal split

### Libraries installed
- `recharts` (already present in the repo)
- `framer-motion` (already present in the repo)