### PR TITLE
fix(gallery): sort hydration mismatch + rename default option to (none)

### DIFF
--- a/__tests__/gallery.test.tsx
+++ b/__tests__/gallery.test.tsx
@@ -53,7 +53,7 @@ describe("Gallery page", () => {
   it("defaults sort to the randomized mode", () => {
     render(<Home />);
     expect(screen.getByRole("combobox", { name: /sort ideas/i })).toHaveValue("random");
-    const defaultOption = screen.getByRole("option", { name: /by default/i }) as HTMLOptionElement;
+    const defaultOption = screen.getByRole("option", { name: /^\(none\)$/ }) as HTMLOptionElement;
     expect(defaultOption.selected).toBe(true);
   });
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,13 +49,17 @@ function HomeContent() {
   const urlSortOrder: SortOrder = urlSortParam === "asc" ? "asc" : urlSortParam === "desc" ? "desc" : "random";
   const [query, setQuery] = useState(urlQuery);
   const [sortOrder, setSortOrder] = useState<SortOrder>(urlSortOrder);
-  const [randomSeed, setRandomSeed] = useState(() => Date.now());
+  const [randomSeed, setRandomSeed] = useState(1);
   const [visibleCount, setVisibleCount] = useState(4);
   const [showBackToTop, setShowBackToTop] = useState(false);
   const [attrOpen, setAttrOpen] = useState(false);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const attrRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setRandomSeed(Date.now());
+  }, []);
 
   useEffect(() => {
     setQuery(urlQuery);
@@ -385,7 +389,7 @@ function HomeContent() {
                     value={sortOrder}
                     onChange={(event) => handleSortChange(event.target.value as SortOrder)}
                   >
-                    <option value="random">- by default</option>
+                    <option value="random">(none)</option>
                     <option value="desc">Newest first</option>
                     <option value="asc">Oldest first</option>
                   </select>


### PR DESCRIPTION
## Summary

- Fixes a Next.js hydration mismatch caused by `useState(() => Date.now())` — server and client produced different seed values, causing a React tree mismatch on mount. Replaced with a stable initial value (`1`) and a mount-only `useEffect` that sets the real seed on the client.
- Renames the default sort option label from `- by default` → `-` → `(none)`.
- Updates the corresponding test matcher.

## Test plan
- [ ] Gallery loads without hydration warnings in the browser console
- [ ] Sort dropdown shows `(none)` as the default option
- [ ] Randomize and sort still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)