### PR TITLE
WIP: feat: add Elder Visit Planner POC (GOOD_SG-008)

### DIFF
--- a/ideas/GOOD_SG.json
+++ b/ideas/GOOD_SG.json
@@ -197,7 +197,8 @@
       "implementation_tags": [
         "drag-reorder"
       ],
-      "implemented": true
+      "implemented": true,
+      "built": true
     },
     {
       "id": "GOOD_SG-005",


### PR DESCRIPTION
## Status

This branch fixes the source of truth for GOOD_SG-008 by adding the missing `built: true` flag in `ideas/GOOD_SG.json`.

The repo snapshot already contains an `elder-visit-planner-sg` route and gallery card, so I did not touch UI files in this round. Per `skills/public/frontend-plan-first/SKILL.md`, any user-facing redesign still stops at planning until explicit approval.

## Design Diversity Audit

1. Last 5 built POCs in reverse order:
- GOOD_SG-076 / Trusted Helper List: `warm civic`, role-clustered contact cards in a phone shell, dynamic quick-dial interactions, title within a phone-style header.
- GOOD_SG-026 / Healthy Hawker Budget: `editorial`, meal-builder spread with animated plan rail, dynamic add-to-plan flow, title in a top editorial hero.
- GOOD_SG-157 / Rain Window Planner: `ambient sensory interface`, wet/dry forecast bands, mostly observational board, title above a full-width board.
- GOOD_SG-156 / Traffic Camera Check: `diagram-first`, route storyboard of camera frames, dynamic route reading, title above a route strip.
- GOOD_SG-086 / Rest Day Planner: `playful utility`, planner board plus activity map, dynamic drag/drop planning, title in a top hero.
2. Forbidden patterns for the next UI pass: phone shell, editorial spread, ambient forecast bands, route storyboard strip, planner grid, top-hero plus content-below rhythm, card clusters, side-rail scheduling form.
3. Chosen `app_type`: `radial-explorer`. It is structurally furthest from the last 5 and would force this concept away from another planner board.
4. Font family: `Bricolage Grotesque`, rotated away from the recent humanist sans choices.
5. Title position: bottom-right inside the radial stage, not top-left or top-center.
6. Surprise factor: the week becomes a visit orbit where seniors sit on spokes and open visit gaps pulse as empty satellite slots waiting to be claimed.

## Concept Read

Idea title: Elder Visit Planner.
Target user: community volunteers.
First screen must communicate: which seniors still need a visit this week, and which day has the clearest gap to fill next.

## Theme and Style

Visual direction: warm civic, but pushed into a radial neighbourhood atlas instead of a scheduler dashboard.
Palette and material feel: warm paper tones, terracotta alerts, deep green availability cues, soft civic texture rather than glossy app chrome.
Typography direction: Bricolage Grotesque with oversized day labels around the orbit.
Motion tone: gentle orbital pulses for missed visits, snap-in confirmations when a visit is assigned.

## Interaction Model

Primary layout: a central radial week wheel with one spoke per day and senior visit tokens orbiting around the centre.
Primary interaction: tap a day spoke, then claim an open orbit slot for a senior and volunteer pairing.
Why this avoids repetition: it replaces the existing calendar-grid plus side-panel shape with a graph-like planning surface.

## Tech Stack

Files that would be edited after approval: `app/pocs/elder-visit-planner-sg/page.tsx`, `app/pocs/elder-visit-planner-sg/page.module.css`, and possibly `app/pocs/elder-visit-planner-sg/data.ts` if the radial grouping needs revised seed data.
Libraries required by the idea spec: `framer-motion`.
Library status this round: no installs were run because the route already exists and `frontend-plan-first` blocks user-facing implementation until approval.
Distinctive feature translation: the current slot pulse becomes orbit gaps that glow until a visit token snaps into place.

## Mandatory Pre-Build Checklist

1. `ui.direction`: `warm civic`, expressed as neighbour-first copy, warm civic colour cues, and low-friction planning.
2. `ui.interaction_model`: originally a weekly calendar grid with visit slots; if redesign is approved, I would override that into a `radial-explorer` while preserving week-at-a-glance planning.
3. `ui.suggested_libraries`: `framer-motion`; already present in the repo, no install needed before a future redesign.
4. `ui.distinctive_feature`: visit slots animate into place and missing coverage gently pulses.
5. `ui.avoid`: no generic scheduling form, no card grid of seniors, no plain calendar clone.
6. First screen message: show where the week still needs someone to visit, with one obvious next assignment.
7. Distinctness check: radial planning surface is materially different from the recent phone shell, editorial spread, ambient board, route strip, and planner board.
8. Back-link check: any approved redesign will keep `← Back to gallery` as the first shell element.

## Anti-Repetition Check

Most likely accidental repeats: `trusted-helper-list-sg`, `healthy-hawker-budget-sg`, `rest-day-planner-sg`, and the current `elder-visit-planner-sg` grid itself.
This plan avoids that by removing the grid-plus-sidebar planner shape entirely and making the orbit map the primary surface.
This is not just cards, chips, chart, map, or scheduler again; the graph-like radial planner is the interface.

## Approval Gate

No user-facing implementation happened in this round beyond the missing JSON `built` flag. If you want the existing Elder Visit Planner UI redesigned to match this audit, approve that direction and I will take the route files forward in a later round.