### PR TITLE
feat: add Lower Your Grocery Bill POC (GOOD_SG-109)

### DIFF
--- a/app/pocs/lower-your-grocery-bill-sg/data.ts
+++ b/app/pocs/lower-your-grocery-bill-sg/data.ts
@@ -1,0 +1,105 @@
+export type GroceryOption = {
+  brand: string;
+  price: number;
+  label: string;
+};
+
+export type GroceryItem = {
+  id: string;
+  name: string;
+  weight: string;
+  category: string;
+  options: [GroceryOption, GroceryOption]; // [0] = budget, [1] = premium
+  defaultPick: 0 | 1;
+};
+
+export const groceryItems: GroceryItem[] = [
+  {
+    id: "rice",
+    name: "Jasmine Rice",
+    weight: "5 kg",
+    category: "Carbs",
+    defaultPick: 1,
+    options: [
+      { brand: "FairPrice Housebrand", price: 6.9, label: "everyday" },
+      { brand: "FairPrice Gold", price: 11.5, label: "premium" },
+    ],
+  },
+  {
+    id: "bread",
+    name: "Whole Wheat Bread",
+    weight: "600 g",
+    category: "Carbs",
+    defaultPick: 1,
+    options: [
+      { brand: "FairPrice Housebrand", price: 1.9, label: "everyday" },
+      { brand: "Gardenia", price: 3.2, label: "popular" },
+    ],
+  },
+  {
+    id: "eggs",
+    name: "Fresh Eggs",
+    weight: "10 pcs",
+    category: "Protein",
+    defaultPick: 1,
+    options: [
+      { brand: "Seng Choon Fresh", price: 2.9, label: "everyday" },
+      { brand: "Happy Egg Co Organic", price: 5.5, label: "organic" },
+    ],
+  },
+  {
+    id: "chicken",
+    name: "Minced Chicken",
+    weight: "500 g, frozen",
+    category: "Protein",
+    defaultPick: 1,
+    options: [
+      { brand: "FairPrice Housebrand", price: 4.5, label: "everyday" },
+      { brand: "Ayamas Premium", price: 7.9, label: "premium" },
+    ],
+  },
+  {
+    id: "tofu",
+    name: "Silken Tofu",
+    weight: "300 g",
+    category: "Vegetables",
+    defaultPick: 1,
+    options: [
+      { brand: "Unicurd", price: 1.2, label: "everyday" },
+      { brand: "Vitasoy", price: 2.1, label: "popular" },
+    ],
+  },
+  {
+    id: "kailan",
+    name: "Kai Lan",
+    weight: "250 g",
+    category: "Vegetables",
+    defaultPick: 1,
+    options: [
+      { brand: "Regular, loose", price: 1.2, label: "everyday" },
+      { brand: "Packaged organic", price: 3.8, label: "organic" },
+    ],
+  },
+  {
+    id: "oil",
+    name: "Sunflower Oil",
+    weight: "1.8 L",
+    category: "Pantry",
+    defaultPick: 1,
+    options: [
+      { brand: "FairPrice Housebrand", price: 4.2, label: "everyday" },
+      { brand: "Naturel", price: 7.8, label: "popular" },
+    ],
+  },
+  {
+    id: "oats",
+    name: "Rolled Oats",
+    weight: "800 g",
+    category: "Pantry",
+    defaultPick: 1,
+    options: [
+      { brand: "FairPrice Housebrand", price: 3.5, label: "everyday" },
+      { brand: "Quaker", price: 5.9, label: "popular" },
+    ],
+  },
+];

--- a/app/pocs/lower-your-grocery-bill-sg/layout.tsx
+++ b/app/pocs/lower-your-grocery-bill-sg/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { getPocBySlug } from "@/lib/pocs";
+
+const poc = getPocBySlug("lower-your-grocery-bill-sg")!;
+
+export const metadata: Metadata = {
+  title: poc.title,
+  description: poc.summary,
+  keywords: poc.tags,
+  openGraph: {
+    title: poc.title,
+    description: poc.summary,
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: poc.title,
+    description: poc.summary,
+  },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/pocs/lower-your-grocery-bill-sg/page.module.css
+++ b/app/pocs/lower-your-grocery-bill-sg/page.module.css
@@ -1,0 +1,316 @@
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,700;9..144,900&family=DM+Sans:wght@400;500;600&family=Space+Mono:wght@400;700&display=swap');
+
+/* ─── Page shell + tokens ────────────────────────────────────── */
+.page {
+  --bg: #F5E8C8;
+  --ink: #1A1410;
+  --ink-muted: #7A6B55;
+  --line: #D8CAA8;
+  --save-green: #1A5C38;
+  --save-green-light: #E8F5EE;
+  --receipt-bg: #1A1410;
+  --receipt-text: #F5E8C8;
+  --receipt-green: #6EBF8B;
+
+  min-height: 100vh;
+  background: var(--bg);
+  font-family: 'DM Sans', sans-serif;
+  color: var(--ink);
+  padding-bottom: 130px;
+}
+
+/* ─── Header ─────────────────────────────────────────────────── */
+.header {
+  max-width: 660px;
+  margin: 0 auto;
+  padding: 48px 24px 36px;
+}
+
+.eyebrow {
+  display: block;
+  font-family: 'Space Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  margin-bottom: 14px;
+}
+
+.title {
+  font-family: 'Fraunces', serif;
+  font-size: clamp(2.6rem, 7vw, 4.2rem);
+  font-weight: 900;
+  line-height: 1.05;
+  color: var(--ink);
+  margin: 0 0 18px;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  font-size: 1.05rem;
+  color: var(--ink-muted);
+  margin: 0;
+  line-height: 1.55;
+  max-width: 400px;
+}
+
+/* ─── Ledger wrapper ─────────────────────────────────────────── */
+.ledgerWrap {
+  max-width: 660px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.ledgerHeading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 2px solid var(--ink);
+  padding: 10px 0 8px;
+  margin-bottom: 4px;
+}
+
+.ledgerLabel {
+  font-family: 'Space Mono', monospace;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-muted);
+}
+
+.ledgerCount {
+  font-family: 'Space Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--ink-muted);
+}
+
+/* ─── Items ──────────────────────────────────────────────────── */
+.ledger {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 0;
+  border-bottom: 1px dashed var(--line);
+  transition: background-color 0.4s ease;
+  /* framer-motion handles bg animation */
+}
+
+.itemLeft {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.category {
+  font-family: 'Space Mono', monospace;
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  flex-shrink: 0;
+  width: 68px;
+  line-height: 1.2;
+}
+
+.itemMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.itemName {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+.itemBrand {
+  font-weight: 400;
+  color: var(--ink-muted);
+}
+
+.itemWeight {
+  font-size: 0.75rem;
+  color: var(--ink-muted);
+}
+
+.itemRight {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.itemPrice {
+  font-family: 'Space Mono', monospace;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--ink);
+  width: 52px;
+  text-align: right;
+  display: inline-block;
+}
+
+/* ─── Swap button ────────────────────────────────────────────── */
+.swapBtn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  background: transparent;
+  font-family: 'Space Mono', monospace;
+  font-size: 0.68rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s;
+  line-height: 1;
+}
+
+.swapBtn:hover {
+  opacity: 0.75;
+}
+
+.swapBtnSave {
+  color: var(--save-green);
+}
+
+.swapBtnSave:hover {
+  background: var(--save-green-light);
+  opacity: 1;
+}
+
+.swapBtnUndo {
+  color: var(--ink-muted);
+}
+
+.swapArrow {
+  font-size: 0.8rem;
+  line-height: 1;
+}
+
+/* ─── Receipt — fixed footer ─────────────────────────────────── */
+.receipt {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--receipt-bg);
+  color: var(--receipt-text);
+  z-index: 10;
+}
+
+.receiptInner {
+  max-width: 660px;
+  margin: 0 auto;
+  padding: 0 24px 20px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  position: relative;
+}
+
+/* ─── The grid-breaking float: total number peeking above ─────── */
+.receiptRight {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  position: relative;
+  /* The total number will overflow upward via margin-top */
+}
+
+.receiptLabel {
+  font-family: 'Space Mono', monospace;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: #A0927A;
+  margin-bottom: 2px;
+  display: block;
+  padding-top: 16px;
+}
+
+.receiptTotal {
+  font-family: 'Space Mono', monospace;
+  font-size: clamp(2rem, 5vw, 2.8rem);
+  font-weight: 700;
+  color: var(--receipt-text);
+  line-height: 1;
+  /* Breaks the grid: overflows upward out of receipt */
+  margin-top: -44px;
+  padding-top: 6px;
+  background: var(--receipt-bg);
+}
+
+/* ─── Receipt left — savings copy ───────────────────────────── */
+.receiptLeft {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 16px;
+}
+
+.receiptSaved {
+  font-size: 0.85rem;
+  color: #A0927A;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.savedAmount {
+  font-family: 'Space Mono', monospace;
+  color: var(--receipt-green);
+  font-weight: 700;
+}
+
+.receiptHint {
+  font-size: 0.82rem;
+  color: #6A5C4A;
+  margin: 0;
+  font-style: italic;
+}
+
+.receiptItemCount {
+  font-family: 'Space Mono', monospace;
+  font-size: 0.65rem;
+  color: #5C4E3A;
+  margin: 0;
+  letter-spacing: 0.05em;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────── */
+@media (max-width: 520px) {
+  .category {
+    display: none;
+  }
+
+  .itemLeft {
+    gap: 0;
+  }
+
+  .itemRight {
+    gap: 6px;
+  }
+
+  .swapBtn {
+    padding: 5px 7px;
+    font-size: 0.62rem;
+  }
+
+  .swapArrow {
+    display: none;
+  }
+}

--- a/app/pocs/lower-your-grocery-bill-sg/page.tsx
+++ b/app/pocs/lower-your-grocery-bill-sg/page.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import styles from "./page.module.css";
+import { groceryItems, type GroceryItem } from "./data";
+
+function useAnimatedValue(target: number, duration = 500) {
+  const [displayed, setDisplayed] = useState(target);
+  const startRef = useRef(target);
+  const animRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const from = startRef.current;
+    const to = target;
+    if (Math.abs(from - to) < 0.001) return;
+
+    const startTime = performance.now();
+    const animate = (now: number) => {
+      const elapsed = now - startTime;
+      const t = Math.min(elapsed / duration, 1);
+      const eased = 1 - Math.pow(1 - t, 3);
+      setDisplayed(from + (to - from) * eased);
+      if (t < 1) {
+        animRef.current = requestAnimationFrame(animate);
+      } else {
+        startRef.current = to;
+      }
+    };
+    if (animRef.current) cancelAnimationFrame(animRef.current);
+    animRef.current = requestAnimationFrame(animate);
+    return () => {
+      if (animRef.current) cancelAnimationFrame(animRef.current);
+    };
+  }, [target, duration]);
+
+  return displayed;
+}
+
+const CATEGORY_COLORS: Record<string, string> = {
+  Carbs: "#7B6D52",
+  Protein: "#5C4A3A",
+  Vegetables: "#3A5C42",
+  Pantry: "#4A4A6A",
+};
+
+export default function LowerYourGroceryBill() {
+  const [picks, setPicks] = useState<Record<string, 0 | 1>>(() =>
+    Object.fromEntries(groceryItems.map((item) => [item.id, item.defaultPick]))
+  );
+  const [justSwapped, setJustSwapped] = useState<string | null>(null);
+
+  const total = groceryItems.reduce(
+    (sum, item) => sum + item.options[picks[item.id]].price,
+    0
+  );
+
+  const maxTotal = groceryItems.reduce(
+    (sum, item) => sum + item.options[1].price,
+    0
+  );
+
+  const saved = maxTotal - total;
+  const swapsUsed = groceryItems.filter((item) => picks[item.id] === 0).length;
+
+  const animatedTotal = useAnimatedValue(total);
+  const animatedSaved = useAnimatedValue(saved);
+
+  const handleSwap = useCallback(
+    (item: GroceryItem) => {
+      setPicks((prev) => ({
+        ...prev,
+        [item.id]: prev[item.id] === 0 ? 1 : 0,
+      }));
+      setJustSwapped(item.id);
+      setTimeout(() => setJustSwapped(null), 700);
+    },
+    []
+  );
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <span className={styles.eyebrow}>Cost of living</span>
+        <h1 className={styles.title}>Lower Your<br />Grocery Bill</h1>
+        <p className={styles.subtitle}>
+          See where a simple swap cuts your weekly total.
+        </p>
+      </header>
+
+      <main className={styles.ledgerWrap}>
+        <div className={styles.ledgerHeading}>
+          <span className={styles.ledgerLabel}>This week&apos;s basket</span>
+          <span className={styles.ledgerCount}>{groceryItems.length} items</span>
+        </div>
+
+        <ul className={styles.ledger} role="list">
+          {groceryItems.map((item) => {
+            const pick = picks[item.id];
+            const current = item.options[pick];
+            const alt = item.options[pick === 0 ? 1 : 0];
+            const canSave = pick === 1;
+            const savings = item.options[1].price - item.options[0].price;
+            const isSwapped = justSwapped === item.id;
+
+            return (
+              <motion.li
+                key={item.id}
+                className={styles.item}
+                animate={
+                  isSwapped
+                    ? { backgroundColor: canSave ? "#E8F5EE" : "#F5E8C8" }
+                    : { backgroundColor: "#F5E8C8" }
+                }
+                transition={{ duration: 0.6 }}
+              >
+                <div className={styles.itemLeft}>
+                  <span
+                    className={styles.category}
+                    style={{ color: CATEGORY_COLORS[item.category] }}
+                  >
+                    {item.category}
+                  </span>
+                  <div className={styles.itemMeta}>
+                    <AnimatePresence mode="wait">
+                      <motion.span
+                        key={current.brand}
+                        className={styles.itemName}
+                        initial={{ opacity: 0, y: 6 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -6 }}
+                        transition={{ duration: 0.2 }}
+                      >
+                        {item.name}
+                        <span className={styles.itemBrand}>
+                          &nbsp;·&nbsp;{current.brand}
+                        </span>
+                      </motion.span>
+                    </AnimatePresence>
+                    <span className={styles.itemWeight}>{item.weight}</span>
+                  </div>
+                </div>
+
+                <div className={styles.itemRight}>
+                  <AnimatePresence mode="wait">
+                    <motion.span
+                      key={current.price}
+                      className={styles.itemPrice}
+                      initial={{ opacity: 0, scale: 0.85 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      exit={{ opacity: 0, scale: 0.85 }}
+                      transition={{ duration: 0.18 }}
+                    >
+                      ${current.price.toFixed(2)}
+                    </motion.span>
+                  </AnimatePresence>
+
+                  <button
+                    className={`${styles.swapBtn} ${canSave ? styles.swapBtnSave : styles.swapBtnUndo}`}
+                    onClick={() => handleSwap(item)}
+                    aria-label={
+                      canSave
+                        ? `Swap to ${alt.brand} and save $${savings.toFixed(2)}`
+                        : `Switch back to ${alt.brand}`
+                    }
+                  >
+                    {canSave ? (
+                      <>
+                        <span className={styles.swapArrow}>↕</span>
+                        <span>Save ${savings.toFixed(2)}</span>
+                      </>
+                    ) : (
+                      <>
+                        <span className={styles.swapArrow}>✓</span>
+                        <span>Saved ${savings.toFixed(2)}</span>
+                      </>
+                    )}
+                  </button>
+                </div>
+              </motion.li>
+            );
+          })}
+        </ul>
+      </main>
+
+      <div className={styles.receipt}>
+        <div className={styles.receiptInner}>
+          <div className={styles.receiptLeft}>
+            {swapsUsed > 0 ? (
+              <motion.p
+                key={swapsUsed}
+                className={styles.receiptSaved}
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+              >
+                You&apos;ve saved{" "}
+                <span className={styles.savedAmount}>
+                  ${animatedSaved.toFixed(2)}
+                </span>{" "}
+                across {swapsUsed} swap{swapsUsed !== 1 ? "s" : ""}
+              </motion.p>
+            ) : (
+              <p className={styles.receiptHint}>
+                Tap a swap to see your total drop
+              </p>
+            )}
+            <p className={styles.receiptItemCount}>
+              {groceryItems.length} items this week
+            </p>
+          </div>
+          <div className={styles.receiptRight}>
+            <span className={styles.receiptLabel}>Total</span>
+            <span className={styles.receiptTotal}>
+              ${animatedTotal.toFixed(2)}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ideas/GOOD_SG.json
+++ b/ideas/GOOD_SG.json
@@ -1715,7 +1715,7 @@
     },
     {
       "id": "GOOD_SG-109",
-      "title": "Grocery Budget Basket",
+      "title": "Lower Your Grocery Bill",
       "platform": "website",
       "folder": "web",
       "build_stack": "Next.js website",
@@ -1785,7 +1785,8 @@
         "experience_goal": "user feels in control of weekly groceries without doing manual math"
       },
       "implementation_tags": [],
-      "implemented": false
+      "implemented": false,
+      "built": true
     },
     {
       "id": "GOOD_SG-037",

--- a/lib/pocs.ts
+++ b/lib/pocs.ts
@@ -12,6 +12,19 @@ export type PocCard = {
 
 export const pocCards: PocCard[] = [
   {
+    slug: "lower-your-grocery-bill-sg",
+    title: "Lower Your Grocery Bill",
+    category: "Cost of living",
+    createdAt: "2026-04-26T23:37:59+08:00",
+    summary:
+      "Swap a brand or two in your weekly basket and watch the total drop in real time.",
+    impact:
+      "A ledger-and-receipt interface where each swap physically updates the running total below.",
+    theme: "civic",
+    tags: ["Groceries", "Budgeting", "Cost of living", "Families", "Singapore"],
+    model: "claude-sonnet-4-6",
+  },
+  {
     slug: "check-my-stress-sg",
     title: "Check My Stress",
     category: "Mental health",


### PR DESCRIPTION
## POC: Lower Your Grocery Bill

Implements idea GOOD_SG-109 (renamed from `Grocery Budget Basket` → passes one-friend test).

**Target user:** families, seniors, and budget-conscious households
**Category:** Cost of living

### What was built
- A ledger-and-receipt interface: 8 Singapore grocery items shown as flat rows (not cards), each with a cheaper swap option
- Swap buttons show the savings potential up-front (`↕ Save $X.XX`); clicking toggles between premium and everyday brand
- Fixed dark receipt footer with an animated running total — the price counts up/down with an ease-out animation on each swap
- Grid-breaking element: the large total price number overflows upward out of the dark receipt panel via negative margin-top, straddling the light/dark boundary
- Design direction: **Warm Ledger & Receipt** — Fraunces serif header (warm parchment bg), DM Sans body, Space Mono for all prices/receipt copy; dark inverted receipt footer; dashed ledger dividers
- Distinctive feature: animated total with real-time savings counter and swap count

### Libraries installed
- `framer-motion` (already in repo) — AnimatePresence for brand/price slide transitions, motion.li for row highlight on swap
- No new installs required